### PR TITLE
feat(io): keep filter for bucket selection active in interactive mode

### DIFF
--- a/internal/io/input.go
+++ b/internal/io/input.go
@@ -19,7 +19,7 @@ func GetCheckboxes(label string, opts []string) []string {
 		Options:  opts,
 		PageSize: SelectionPageSize,
 	}
-	survey.AskOne(prompt, &res)
+	survey.AskOne(prompt, &res, survey.WithKeepFilter(true))
 
 	return res
 }


### PR DESCRIPTION
Until now, if we entered a filter word on the selection screen and then selected any choice, the word we entered was cleared and all items were displayed again. With this change, the filter word will persist.

```
? Select buckets.
 eu-west  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
  [x]  cdk-hnb659fds-assets-123456789012-eu-west-1
> [x]  cdk-hnb659fds-assets-123456789012-eu-west-2
```