### PR TITLE
feat(wrapper): output the number of objects with an error

### DIFF
--- a/internal/wrapper/s3_wrapper.go
+++ b/internal/wrapper/s3_wrapper.go
@@ -118,7 +118,9 @@ func (s *S3Wrapper) ClearS3Objects(
 		return err
 	}
 
-	writer.Flush()
+	if err := writer.Flush(); err != nil {
+		return err
+	}
 
 	if deletedVersionsCount == 0 {
 		io.Logger.Info().Msgf("%v No objects.", bucketName)

--- a/internal/wrapper/s3_wrapper.go
+++ b/internal/wrapper/s3_wrapper.go
@@ -122,22 +122,19 @@ func (s *S3Wrapper) ClearS3Objects(
 		return err
 	}
 
+	if errorsCount > 0 {
+		// The error is from `DeleteObjectsOutput.Errors`, not `err`.
+		// However, we want to treat it as an error, so we use `client.ClientError`.
+		return &client.ClientError{
+			ResourceName: aws.String(bucketName),
+			Err:          fmt.Errorf("DeleteObjectsError: %v objects with errors were found. %v", errorsCount, errorStr),
+		}
+	}
+
 	if deletedVersionsCount == 0 {
 		io.Logger.Info().Msgf("%v No objects.", bucketName)
 	} else {
-		if errorsCount > 0 {
-			deletedVersionsCount -= errorsCount
-		}
-
 		io.Logger.Info().Msgf("%v Cleared!!: %v objects.", bucketName, deletedVersionsCount)
-		if errorsCount > 0 {
-			// The error is from `DeleteObjectsOutput.Errors`, not `err`.
-			// However, we want to treat it as an error, so we use `client.ClientError`.
-			return &client.ClientError{
-				ResourceName: aws.String(bucketName),
-				Err:          fmt.Errorf("DeleteObjectsError: %v objects with errors were found. %v", errorsCount, errorStr),
-			}
-		}
 	}
 
 	if forceMode {

--- a/internal/wrapper/s3_wrapper.go
+++ b/internal/wrapper/s3_wrapper.go
@@ -128,8 +128,8 @@ func (s *S3Wrapper) ClearS3Objects(
 		}
 
 		io.Logger.Info().Msgf("%v Cleared!!: %v objects.", bucketName, deletedVersionsCount)
-		if errorStr != "" {
-			return fmt.Errorf("DeleteObjectsError: followings %v", errorStr)
+		if errorsCount > 0 {
+			return fmt.Errorf("DeleteObjectsError: %v objects with errors were found. %v", errorsCount, errorStr)
 		}
 	}
 

--- a/internal/wrapper/s3_wrapper.go
+++ b/internal/wrapper/s3_wrapper.go
@@ -129,7 +129,10 @@ func (s *S3Wrapper) ClearS3Objects(
 
 		io.Logger.Info().Msgf("%v Cleared!!: %v objects.", bucketName, deletedVersionsCount)
 		if errorsCount > 0 {
-			return fmt.Errorf("DeleteObjectsError: %v objects with errors were found. %v", errorsCount, errorStr)
+			return &client.ClientError{
+				ResourceName: aws.String(bucketName),
+				Err:          fmt.Errorf("DeleteObjectsError: %v objects with errors were found. %v", errorsCount, errorStr),
+			}
 		}
 	}
 

--- a/internal/wrapper/s3_wrapper.go
+++ b/internal/wrapper/s3_wrapper.go
@@ -129,6 +129,8 @@ func (s *S3Wrapper) ClearS3Objects(
 
 		io.Logger.Info().Msgf("%v Cleared!!: %v objects.", bucketName, deletedVersionsCount)
 		if errorsCount > 0 {
+			// The error is from `DeleteObjectsOutput.Errors`, not `err`.
+			// However, we want to treat it as an error, so we use `client.ClientError`.
 			return &client.ClientError{
 				ResourceName: aws.String(bucketName),
 				Err:          fmt.Errorf("DeleteObjectsError: %v objects with errors were found. %v", errorsCount, errorStr),

--- a/internal/wrapper/s3_wrapper_test.go
+++ b/internal/wrapper/s3_wrapper_test.go
@@ -199,7 +199,7 @@ func TestS3Wrapper_ClearS3Objects(t *testing.T) {
 					}, nil,
 				)
 			},
-			want:    fmt.Errorf("DeleteObjectsError: 1 objects with errors were found. \nCode: Code\nKey: Key\nVersionId: VersionId\nMessage: Message\n"),
+			want:    fmt.Errorf("[resource test] DeleteObjectsError: 1 objects with errors were found. \nCode: Code\nKey: Key\nVersionId: VersionId\nMessage: Message\n"),
 			wantErr: true,
 		},
 		{
@@ -387,7 +387,7 @@ func TestS3Wrapper_ClearS3Objects(t *testing.T) {
 					}, nil,
 				)
 			},
-			want:    fmt.Errorf("DeleteObjectsError: 1 objects with errors were found. \nCode: Code\nKey: Key\nVersionId: VersionId\nMessage: Message\n"),
+			want:    fmt.Errorf("[resource test] DeleteObjectsError: 1 objects with errors were found. \nCode: Code\nKey: Key\nVersionId: VersionId\nMessage: Message\n"),
 			wantErr: true,
 		},
 		{

--- a/internal/wrapper/s3_wrapper_test.go
+++ b/internal/wrapper/s3_wrapper_test.go
@@ -199,7 +199,7 @@ func TestS3Wrapper_ClearS3Objects(t *testing.T) {
 					}, nil,
 				)
 			},
-			want:    fmt.Errorf("DeleteObjectsError: followings \nCode: Code\nKey: Key\nVersionId: VersionId\nMessage: Message\n"),
+			want:    fmt.Errorf("DeleteObjectsError: 1 objects with errors were found. \nCode: Code\nKey: Key\nVersionId: VersionId\nMessage: Message\n"),
 			wantErr: true,
 		},
 		{
@@ -387,7 +387,7 @@ func TestS3Wrapper_ClearS3Objects(t *testing.T) {
 					}, nil,
 				)
 			},
-			want:    fmt.Errorf("DeleteObjectsError: followings \nCode: Code\nKey: Key\nVersionId: VersionId\nMessage: Message\n"),
+			want:    fmt.Errorf("DeleteObjectsError: 1 objects with errors were found. \nCode: Code\nKey: Key\nVersionId: VersionId\nMessage: Message\n"),
 			wantErr: true,
 		},
 		{

--- a/testdata/deploy.sh
+++ b/testdata/deploy.sh
@@ -40,7 +40,7 @@ dir="./testfiles/${bucket_name}"
 mkdir -p ${dir}
 
 # about 100,000 versions
-for i in $(seq 1 25); do
+for i in $(seq 1 250); do
 	touch ${dir}/${i}_{1..1000}_${RANDOM}.txt
 
 	# version

--- a/testdata/deploy.sh
+++ b/testdata/deploy.sh
@@ -40,7 +40,7 @@ dir="./testfiles/${bucket_name}"
 mkdir -p ${dir}
 
 # about 100,000 versions
-for i in $(seq 1 250); do
+for i in $(seq 1 25); do
 	touch ${dir}/${i}_{1..1000}_${RANDOM}.txt
 
 	# version


### PR DESCRIPTION
- The situation
  - 1000 deletions
  - 10 errors
- In the case, cls3 displays the messages now
  - Clearing... 1000 objects
  - DeleteObjectsError: followings ...
- This PR supports to display the following messages:
  - Clearing... 1000 objects
  - DeleteObjectsError: 10 objects with errors were found.

**But this change can only cover objects with the error in `output.Errors` not `err` from `DeleteObjects`.** 

```
Code: InternalError
Key: 1548_994_6279.txt
VersionId: xp.ZtEsKtzzwfqLPC75295nve4FUBshZ
Message: We encountered an internal error. Please try again.

Code: InternalError
Key: 1549_92_24844.txt
VersionId: 68q3pjHpAIee6NS3hh0SKwFPFY0G2xNh
Message: We encountered an internal error. Please try again.

Code: InternalError
Key: 1593_161_10029.txt
VersionId: a8UmOuU4smKnTUpNWs4oKx2QeJt1dsmG
Message: We encountered an internal error. Please try again.
```