### PR TITLE
feat(client): retry internal retryable errors

### DIFF
--- a/pkg/client/s3.go
+++ b/pkg/client/s3.go
@@ -138,19 +138,14 @@ func (s *S3) DeleteObjects(
 					VersionId: err.VersionId,
 				})
 			} else {
-				// Set all errors and break if there is at least one non-retryable error.
-				errors = append(errors, output.Errors...)
-				break
+				errors = append(errors, err)
 			}
 		}
-		// Exit if there is at least one non-retryable error.
-		if len(errors) > 0 {
-			break
-		}
-
 		// random sleep
-		sleepTime, _ := retryer.RetryDelay(0, nil)
-		time.Sleep(sleepTime)
+		if len(objects) > 0 {
+			sleepTime, _ := retryer.RetryDelay(0, nil)
+			time.Sleep(sleepTime)
+		}
 	}
 
 	return errors, nil

--- a/pkg/client/s3.go
+++ b/pkg/client/s3.go
@@ -9,8 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/go-to-k/cls3/internal/io"
-	"github.com/go-to-k/cls3/internal/version"
 )
 
 var SleepTimeSecForS3 = 10
@@ -102,9 +100,6 @@ func (s *S3) DeleteObjects(
 
 		retryable := func(err error) bool {
 			isErrorRetryable := strings.Contains(err.Error(), "api error SlowDown")
-			if isErrorRetryable {
-				io.Logger.Debug().Msgf("Retry: %s", err.Error())
-			}
 			return isErrorRetryable
 		}
 		retryer := NewRetryer(retryable, SleepTimeSecForS3)
@@ -151,11 +146,6 @@ func (s *S3) DeleteObjects(
 		// Exit if there is at least one non-retryable error.
 		if len(errors) > 0 {
 			break
-		}
-		if version.IsDebug() {
-			for _, object := range objects {
-				io.Logger.Debug().Msgf("Retry: key=%v, versionId=%d", object.Key, object.VersionId)
-			}
 		}
 
 		// random sleep

--- a/pkg/client/s3.go
+++ b/pkg/client/s3.go
@@ -85,7 +85,7 @@ func (s *S3) DeleteObjects(
 
 	for {
 		// Assuming that the number of objects received as an argument does not
-		// exceed 1000, so no loop processing and validation whether exceeds
+		// exceed 1000, so no slice splitting and validation whether exceeds
 		// 1000 or not are good.
 		if len(objects) == 0 {
 			break
@@ -119,7 +119,9 @@ func (s *S3) DeleteObjects(
 			}
 		}
 
-		if output.Errors != nil && len(output.Errors) > 0 {
+		if len(output.Errors) == 0 {
+			break
+		} else {
 			retryCounts++
 
 			// TODO: sleep!!!!

--- a/pkg/client/s3_test.go
+++ b/pkg/client/s3_test.go
@@ -30,16 +30,16 @@ func getNextMarkerForS3Initialize(
 	return next.HandleInitialize(ctx, in)
 }
 
-type targetObjectsForS3 struct{}
+type targetObjectsForDeleteObjects struct{}
 
-func setTargetObjectsForS3Initialize(
+func setTargetObjectsForDeleteObjectsInitialize(
 	ctx context.Context, in middleware.InitializeInput, next middleware.InitializeHandler,
 ) (
 	out middleware.InitializeOutput, metadata middleware.Metadata, err error,
 ) {
 	switch v := in.Parameters.(type) {
 	case *s3.DeleteObjectsInput:
-		ctx = middleware.WithStackValue(ctx, targetObjectsForS3{}, v.Delete.Objects)
+		ctx = middleware.WithStackValue(ctx, targetObjectsForDeleteObjects{}, v.Delete.Objects)
 	}
 	return next.HandleInitialize(ctx, in)
 }
@@ -371,7 +371,7 @@ func TestS3_DeleteObjects(t *testing.T) {
 					err := stack.Initialize.Add(
 						middleware.InitializeMiddlewareFunc(
 							"SetTargetObjects",
-							setTargetObjectsForS3Initialize,
+							setTargetObjectsForDeleteObjectsInitialize,
 						), middleware.Before,
 					)
 					if err != nil {
@@ -380,9 +380,9 @@ func TestS3_DeleteObjects(t *testing.T) {
 
 					return stack.Finalize.Add(
 						middleware.FinalizeMiddlewareFunc(
-							"DeleteObjectsErrorsMock",
+							"DeleteObjectsWithRetryableErrorsMock",
 							func(ctx context.Context, input middleware.FinalizeInput, handler middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
-								objects := middleware.GetStackValue(ctx, targetObjectsForS3{}).([]types.ObjectIdentifier)
+								objects := middleware.GetStackValue(ctx, targetObjectsForDeleteObjects{}).([]types.ObjectIdentifier)
 								var errors []types.Error
 								// first loop
 								if len(objects) == 3 {
@@ -444,7 +444,7 @@ func TestS3_DeleteObjects(t *testing.T) {
 				withAPIOptionsFunc: func(stack *middleware.Stack) error {
 					return stack.Finalize.Add(
 						middleware.FinalizeMiddlewareFunc(
-							"DeleteObjectsErrorsMock",
+							"DeleteObjectsWithRetryableErrorsMock",
 							func(ctx context.Context, input middleware.FinalizeInput, handler middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
 								return middleware.FinalizeOutput{
 									Result: &s3.DeleteObjectsOutput{
@@ -501,7 +501,7 @@ func TestS3_DeleteObjects(t *testing.T) {
 					err := stack.Initialize.Add(
 						middleware.InitializeMiddlewareFunc(
 							"SetTargetObjects",
-							setTargetObjectsForS3Initialize,
+							setTargetObjectsForDeleteObjectsInitialize,
 						), middleware.Before,
 					)
 					if err != nil {
@@ -510,9 +510,9 @@ func TestS3_DeleteObjects(t *testing.T) {
 
 					return stack.Finalize.Add(
 						middleware.FinalizeMiddlewareFunc(
-							"DeleteObjectsErrorsMock",
+							"DeleteObjectsWithRetryableErrorsMock",
 							func(ctx context.Context, input middleware.FinalizeInput, handler middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
-								objects := middleware.GetStackValue(ctx, targetObjectsForS3{}).([]types.ObjectIdentifier)
+								objects := middleware.GetStackValue(ctx, targetObjectsForDeleteObjects{}).([]types.ObjectIdentifier)
 								var errors []types.Error
 								// first loop
 								if len(objects) == 3 {
@@ -582,7 +582,7 @@ func TestS3_DeleteObjects(t *testing.T) {
 					err := stack.Initialize.Add(
 						middleware.InitializeMiddlewareFunc(
 							"SetTargetObjects",
-							setTargetObjectsForS3Initialize,
+							setTargetObjectsForDeleteObjectsInitialize,
 						), middleware.Before,
 					)
 					if err != nil {
@@ -591,9 +591,9 @@ func TestS3_DeleteObjects(t *testing.T) {
 
 					return stack.Finalize.Add(
 						middleware.FinalizeMiddlewareFunc(
-							"DeleteObjectsErrorsMock",
+							"DeleteObjectsWithRetryableErrorsMock",
 							func(ctx context.Context, input middleware.FinalizeInput, handler middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
-								objects := middleware.GetStackValue(ctx, targetObjectsForS3{}).([]types.ObjectIdentifier)
+								objects := middleware.GetStackValue(ctx, targetObjectsForDeleteObjects{}).([]types.ObjectIdentifier)
 								var errors []types.Error
 								// first loop
 								if len(objects) == 3 {

--- a/pkg/client/s3_test.go
+++ b/pkg/client/s3_test.go
@@ -348,7 +348,7 @@ func TestS3_DeleteObjects(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "don't return errors when retry succeeds",
+			name: "does not return errors when retry succeeds",
 			args: args{
 				ctx:        context.Background(),
 				bucketName: aws.String("test"),

--- a/pkg/client/s3_test.go
+++ b/pkg/client/s3_test.go
@@ -604,7 +604,7 @@ func TestS3_DeleteObjects(t *testing.T) {
 											Message:   aws.String("We encountered an internal error. Please try again."),
 											VersionId: aws.String("VersionId1"),
 										},
-										// 2nd and 3rd object is not an error
+										// 2nd and 3rd objects are not errors
 									}
 								} else {
 									errors = []types.Error{


### PR DESCRIPTION
`DeleteObjects` often returns `output.Errors` instead of `err`. It often has an retryable error, so cls3 should retry the deletion.

```
Code: InternalError
Key: 1548_994_6279.txt
VersionId: xp.ZtEsKtzzwfqLPC75295nve4FUBshZ
Message: We encountered an internal error. Please try again.

Code: InternalError
Key: 1549_92_24844.txt
VersionId: 68q3pjHpAIee6NS3hh0SKwFPFY0G2xNh
Message: We encountered an internal error. Please try again.

Code: InternalError
Key: 1593_161_10029.txt
VersionId: a8UmOuU4smKnTUpNWs4oKx2QeJt1dsmG
Message: We encountered an internal error. Please try again.
```