### PR TITLE
fix(wrapper): TooManyRequestsException often occurs

### DIFF
--- a/internal/wrapper/s3_tables_wrapper.go
+++ b/internal/wrapper/s3_tables_wrapper.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Too Many Requests error often occurs, so limit the value
-const SemaphoreWeight = 5
+const SemaphoreWeight = 4
 
 var _ IWrapper = (*S3TablesWrapper)(nil)
 


### PR DESCRIPTION
So to be lower the number of parallels in s3 tables wrapper.