### PR TITLE
revert: "chore(wrapper): change handling errgroup with context (#289)"

### DIFF
--- a/internal/wrapper/s3_tables_wrapper.go
+++ b/internal/wrapper/s3_tables_wrapper.go
@@ -36,7 +36,7 @@ func (s *S3TablesWrapper) deleteNamespace(
 	namespace string,
 	progressCh chan<- struct{},
 ) error {
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	sem := semaphore.NewWeighted(SemaphoreWeight)
 
 	var continuationToken *string
@@ -118,7 +118,7 @@ func (s *S3TablesWrapper) ClearBucket(
 		}
 	}()
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	sem := semaphore.NewWeighted(SemaphoreWeight)
 	var continuationToken *string
 	for {

--- a/internal/wrapper/s3_wrapper.go
+++ b/internal/wrapper/s3_wrapper.go
@@ -39,7 +39,7 @@ func (s *S3Wrapper) ClearBucket(
 		return err
 	}
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg := errgroup.Group{}
 	errorStr := ""
 	errorsCount := 0
 	errorsMtx := sync.Mutex{}


### PR DESCRIPTION
This reverts commit f270ed23eace53daec383f9f50bb6631470b903a.

```
		// failed if 4 buckets
		// INF par-cls-012 Checking...
		// INF par-cls-010 Checking...
		// INF par-cls-009 Checking...
		// INF par-cls-011 Checking...
		// INF par-cls-009 No objects.
		// ERR [resource par-cls-009] operation error S3: DeleteBucket, context canceled
		// Even if 1 bucket par-cls-009, it doesn't work.
		// INF par-cls-009 Checking...
		// INF par-cls-009 No objects.
		// ERR [resource par-cls-009] operation error S3: DeleteBucket, context canceled
```