### PR TITLE
fix(wrapper): S3 Tables Wrapper is loading without waiting for the addition process of deletedTablesCount

### DIFF
--- a/internal/wrapper/s3_tables_wrapper.go
+++ b/internal/wrapper/s3_tables_wrapper.go
@@ -119,6 +119,7 @@ func (s *S3TablesWrapper) ClearBucket(
 				fmt.Fprintf(writer, "Clearing... %d tables\n", count)
 			}
 		}
+		wg.Done()
 	}()
 
 	eg := errgroup.Group{}

--- a/internal/wrapper/s3_tables_wrapper.go
+++ b/internal/wrapper/s3_tables_wrapper.go
@@ -113,6 +113,7 @@ func (s *S3TablesWrapper) ClearBucket(
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for range progressCh {
 			count := deletedTablesCount.Add(1)
 			if !input.QuietMode {

--- a/internal/wrapper/s3_tables_wrapper.go
+++ b/internal/wrapper/s3_tables_wrapper.go
@@ -120,7 +120,6 @@ func (s *S3TablesWrapper) ClearBucket(
 				fmt.Fprintf(writer, "Clearing... %d tables\n", count)
 			}
 		}
-		wg.Done()
 	}()
 
 	eg := errgroup.Group{}

--- a/internal/wrapper/s3_tables_wrapper_test.go
+++ b/internal/wrapper/s3_tables_wrapper_test.go
@@ -663,10 +663,10 @@ func TestS3TablesWrapper_deleteNamespace(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				for range progressCh {
 					deletedCount.Add(1)
 				}
-				wg.Done()
 			}()
 
 			err := s3Tables.deleteNamespace(tt.args.ctx, tt.args.bucketArn, tt.args.bucketName, tt.args.namespace, progressCh)


### PR DESCRIPTION
I could know this because CI happened to fail.

https://github.com/go-to-k/cls3/actions/runs/13030880930/job/36349706622?pr=288
